### PR TITLE
Add `--no-meta` flag to skip downloading activity metadata 

### DIFF
--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -186,11 +186,14 @@ class StravaBackup:
         os.makedirs(path, exist_ok=True)
         return os.path.join(path, filename)
 
-    def have_activity(self, activity, photos=True):
+    def have_activity(self, activity, photos=True, metadata=True):
         """Check if we have an activity (and all it's photos)"""
         h = self._have[activity.id]
 
-        if not h[0] or (not h[1] and not activity.manual):
+        if metadata and not h[0]:
+            return False
+
+        if not h[1] and not activity.manual:
             return False
 
         if not photos:
@@ -258,14 +261,14 @@ class StravaBackup:
                         if chunk:
                             f.write(chunk)
 
-    def backup_activities(self, *, limit=None, photos=True, dry_run=False):
+    def backup_activities(self, *, limit=None, metadata=True, photos=True, dry_run=False):
         count = 0
         for a in self._activities():
 
             if limit is not None and count >= limit:
                 return
 
-            if self.have_activity(a, photos=photos):
+            if self.have_activity(a, photos=photos, metadata=metadata):
                 continue
 
             count += 1
@@ -275,7 +278,7 @@ class StravaBackup:
             if dry_run:
                 if not a.manual and not have_data:
                     __log__.info("Would download activity %s", a)
-                elif not have_meta:
+                elif metadata and not have_meta:
                     __log__.info("Would download metadata for activity %s", a)
 
                 if photos and a.total_photo_count:
@@ -283,14 +286,18 @@ class StravaBackup:
 
                 continue
 
-            # Get the fully-detailed activity
-            a = self.client.get_activity(a.id)
+            need_photos = photos and a.total_photo_count
+            need_metadata =  metadata and not have_meta
 
-            if photos and a.total_photo_count:
+            # Get the fully-detailed activity for photos and metadata
+            if need_photos or need_metadata:
+                a = self.client.get_activity(a.id)
+
+            if need_photos:
                 __log__.info("Downloading %d photo(s) from activity %s", a.total_photo_count, a)
                 self.backup_photos(a.id, photo_data)
 
-            if not have_meta:
+            if need_metadata:
                 with open(self._data_path(a), 'w') as f:
                     json_dump(a, f)
 
@@ -307,7 +314,7 @@ class StravaBackup:
                         if chunk:
                             f.write(chunk)
 
-    def run_backup(self, *, limit=None, gear=True, photos=True, dry_run=False):
+    def run_backup(self, *, limit=None, metadata=True, gear=True, photos=True, dry_run=False):
 
         if not dry_run:
             self._ensure_output_dirs(gear=gear, photos=photos)
@@ -315,4 +322,4 @@ class StravaBackup:
         if gear:
             self.backup_gear(dry_run=dry_run)
 
-        self.backup_activities(limit=limit, photos=photos, dry_run=dry_run)
+        self.backup_activities(limit=limit, metadata=metadata, photos=photos, dry_run=dry_run)

--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -257,9 +257,7 @@ class StravaBackup:
                 resp = requests.get(url, stream=True)
                 # TODO: Check for filetype instead of assuming jpg
                 with open(self._data_path(p, ext="jpg"), 'wb') as f:
-                    for chunk in resp.iter_content(chunk_size=16384):
-                        if chunk:
-                            f.write(chunk)
+                    f.writelines(resp.iter_content(chunk_size=16384))
 
     def backup_activities(self, *, limit=None, metadata=True, photos=True, dry_run=False):
         count = 0
@@ -310,9 +308,7 @@ class StravaBackup:
 
                 __log__.info("Downloading activity %s (%s)", a, data.filename)
                 with open(self._data_path(a, ext=ext), 'wb') as f:
-                    for chunk in data.content:
-                        if chunk:
-                            f.write(chunk)
+                    f.writelines(data.content)
 
     def run_backup(self, *, limit=None, metadata=True, gear=True, photos=True, dry_run=False):
 

--- a/stravabackup/__main__.py
+++ b/stravabackup/__main__.py
@@ -14,7 +14,7 @@ from stravalib import Client
 __log__ = logging.getLogger(__name__)
 
 
-LOG_FORMAT = "%(asctime)s : [%(levelname)8s] %(message)s"
+LOG_FORMAT = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
 CONFIG_FILE = os.path.join(
     os.environ.get('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config')),
     'strava-backup.conf'

--- a/stravabackup/__main__.py
+++ b/stravabackup/__main__.py
@@ -35,6 +35,8 @@ def main():
     parser.add_argument("--limit", nargs="?", type=int, default=None,
                         help="The maximum number of activities to back up in "
                              "a single run (default: %(default)s)")
+    parser.add_argument("--no-meta", action="store_true", default=False,
+                        help="Don't download activity metadata")
     parser.add_argument("--no-gear", action="store_true", default=False,
                         help="Don't download gear information")
     parser.add_argument("--no-photos", action="store_true", default=False,
@@ -99,7 +101,10 @@ def main():
 
     sb = StravaBackup(access_token, email, password, output_dir)
     return sb.run_backup(
-        limit=args.limit, gear=not args.no_gear, photos=not args.no_photos,
+        limit=args.limit,
+        metadata=not args.no_meta,
+        gear=not args.no_gear,
+        photos=not args.no_photos,
         dry_run=args.dry_run
     )
 


### PR DESCRIPTION
This allows skipping the API call to get the detailed activity data if all that's required is the actual activity data.