### PR TITLE
activity backup: also include total_elevation_gain, average_speed and…

### DIFF
--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -41,6 +41,12 @@ def valid_unit(unit):
         denom = unit.denom
         if len(numer) == len(denom) == 1:
             return valid_unit(numer) and valid_unit(denom)
+    elif isinstance(unit, list):
+        # Allow e.g. m/s as a unit.
+        for i in unit:
+            if not valid_unit(i):
+                return False
+        return True
     return False
 
 
@@ -65,7 +71,8 @@ def obj_to_json(obj):
                                              "distance", "start_date",
                                              "moving_time", "elapsed_time",
                                              "calories", "device_name",
-                                             "gear_id")}
+                                             "gear_id", "total_elevation_gain",
+                                             "average_speed", "max_speed")}
     elif isinstance(obj, stravalib.model.Gear):
         d = {p: getattr(obj, p) for p in ('id', 'name', 'brand_name',
                                           'model_name', 'description')}

--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -42,11 +42,8 @@ def valid_unit(unit):
         if len(numer) == len(denom) == 1:
             return valid_unit(numer) and valid_unit(denom)
     elif isinstance(unit, list):
-        # Allow e.g. m/s as a unit.
-        for i in unit:
-            if not valid_unit(i):
-                return False
-        return True
+        # units can be a list of units (ex: m/s)
+        return all(valid_unit(x) for x in unit)
     return False
 
 


### PR DESCRIPTION
… max_speed

The unit of speed is typically m/s, so also accept a list of units in valid_unit(): if all items of the list are valid, then consider the list as valid, too.

With this, all the 6 stats included for an activity in the mobile app are also tracked in .meta.json.