### PR TITLE
Add the possibility to auth with a JWT instead of a password

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ However, this is only available on the website and not via the API.
 This tool uses the API to get a list of all your events, then web scraping to log into the site
 using your username and password and download the original files for all your activities.
 
+It's possible to give your username and your JWT token instead of your password: that token is only
+valid for 30 days, but it can work in cases where your password alone is not accepted.
+
 The "original file" will usually be either a `*.fit` file (most Garmin devices), `*.tcx`, `*.gpx`,
 or `*.json` (Strava mobile application).
 

--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -97,12 +97,16 @@ def json_dump(*args, **kwargs):
 class StravaBackup:
     """Download your data from Strava"""
 
-    def __init__(self, access_token, email, password, out_dir):
+    def __init__(self, access_token, email, password, jwt, out_dir):
         self.out_dir = out_dir
 
         # Will attempt to log in using the username/password
-        self.client = WebClient(access_token=access_token, email=email,
-                                password=password)
+        if jwt:
+            self.client = WebClient(access_token=access_token, email=email,
+                                    jwt=jwt)
+        else:
+            self.client = WebClient(access_token=access_token, email=email,
+                                    password=password)
         self._have = self._find_existing_data()
 
     def __enter__(self):

--- a/stravabackup/__main__.py
+++ b/stravabackup/__main__.py
@@ -60,7 +60,12 @@ def main():
     refresh_token = config['api']['refresh_token']
     output_dir = os.path.expanduser(config['global'].get('output_dir', OUTPUT_DIR))
     email = config['user']['email']
-    password = config['user']['password']
+    if 'jwt' in config['user']:
+        jwt = config['user']['jwt']
+        password = None
+    else:
+        jwt = None
+        password = config['user']['password']
 
     # Reduce logspam
     logging.getLogger("stravalib.model").setLevel(logging.INFO)
@@ -100,7 +105,7 @@ def main():
     else:
         __log__.info("Backing up '%s' to '%s'", email, output_dir)
 
-    sb = StravaBackup(access_token, email, password, output_dir)
+    sb = StravaBackup(access_token, email, password, jwt, output_dir)
     return sb.run_backup(
         limit=args.limit,
         metadata=not args.no_meta,

--- a/stravabackup/strava-backup.conf
+++ b/stravabackup/strava-backup.conf
@@ -9,3 +9,4 @@ refresh_token=<YOUR API REFRESH TOKEN>
 [user]
 email=<YOUR EMAIL>
 password=<YOUR PASSWORD>
+#jwt=<YOUR JWT>


### PR DESCRIPTION
Password login is broken for me (it would require to provide a 6 digit number in 5 minutes, sent to the email address); JWT is less great than the old password login, but it's an acceptable interim solution till login would just completely fail.

Fixes <https://github.com/pR0Ps/strava-backup/issues/11>.