### PR TITLE
Add support for using+caching JWT tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ In order to back up your data, `strava-backup` can use the following scopes (all
 - `activity:read` ("View data about your activities"): Will read and backup activity data
 - `activity:read_all` ("View data about your private activities"): Will read and backup private activity data
 
+Accessing the activity data requires web scraping which requires logging into the website. This
+requires either a username and password, or a JWT token from a previously-authenticated session.
+Note that JWT tokens expire periodically so providing a username and password is required for
+running the backup on an ongoing basis.
 
 Setup
 -----

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ setup(
     python_requires=">=3.4",
     packages=["stravabackup"],
     package_data={"stravabackup": ["strava-backup.conf"]},
-    install_requires=["stravaweblib>=0.0.8,<1.0.0", "stravalib>=0.10.4,<1.0.0"],
+    install_requires=[
+        "stravaweblib>=0.0.8,<1.0.0",
+        "stravalib>=0.10.4,<1.0.0",
+        "commented-configparser>=2,<3",
+    ],
     entry_points={'console_scripts': ["strava-backup=stravabackup.__main__:main"]}
 )

--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -128,6 +128,10 @@ class StravaBackup:
     def gear_dir(self):
         return os.path.join(self.out_dir, "gear")
 
+    @property
+    def jwt(self):
+        return self.client.jwt
+
     @staticmethod
     def _validate_jwt(jwt):
         """Validate the JWT
@@ -153,7 +157,7 @@ class StravaBackup:
             __log__.error("Provided JWT token expired on %s - ignoring it", expiry)
             return None
 
-        __log__.warning(
+        __log__.info(
             "Using a JWT token that will expire on %s (in %s)",
             expiry,
             expiry-now

--- a/stravabackup/__main__.py
+++ b/stravabackup/__main__.py
@@ -61,6 +61,7 @@ def main():
     output_dir = os.path.expanduser(config['global'].get('output_dir', OUTPUT_DIR))
     email = config['user']['email']
     password = config['user']['password']
+    jwt = config['user'].get('jwt')
 
     # Reduce logspam
     logging.getLogger("stravalib.model").setLevel(logging.INFO)
@@ -100,7 +101,13 @@ def main():
     else:
         __log__.info("Backing up '%s' to '%s'", email, output_dir)
 
-    sb = StravaBackup(access_token, email, password, output_dir)
+    sb = StravaBackup(
+        access_token=access_token,
+        email=email,
+        password=password,
+        jwt=jwt,
+        out_dir=output_dir,
+    )
     return sb.run_backup(
         limit=args.limit,
         metadata=not args.no_meta,

--- a/stravabackup/__main__.py
+++ b/stravabackup/__main__.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
 import argparse
-import configparser
+import contextlib
+import io
 import logging
 import os
-import re
 import sys
 
+from commentedconfigparser import CommentedConfigParser
 from stravabackup import StravaBackup
 from stravalib import Client
 
@@ -24,6 +25,47 @@ OUTPUT_DIR = os.path.join(
     os.environ.get('XDG_DATA_HOME', os.path.join(HOME, ".local", "share")),
     "strava-backup"
 )
+
+
+@contextlib.contextmanager
+def _manage_config(fp):
+    """Handle reading/writing the config file
+
+    If the config is updated within this context manager, the config file will
+    be rewritten when it exits.
+    """
+    config = CommentedConfigParser()
+    config.read_file(fp)
+
+    # ensure that we only try to write the config out if it was passed via an actual file
+    path = getattr(fp, "name", None)
+    can_write = path and path != "<stdin>" and os.path.isfile(path)
+
+    # janky way to track updates - if set to true, the config will be rewritten
+    config._updated = False
+
+    try:
+        yield config
+    finally:
+        if config._updated:
+            __log__.info("Config changed, attempting to update the config file")
+            s = io.StringIO()
+            config.write(s)
+            new_config = s.getvalue()
+            try:
+                if not can_write:
+                    raise FileNotFoundError("Cannot rewrite config - input config was a non-file")
+                with open(path, 'wt') as f:
+                    f.write(new_config)
+            except OSError:
+                __log__.warning(
+                    "Failed to automatically update the config file - "
+                    "please update it manually with the following contents:\n```%s\n```",
+                    new_config,
+                    exc_info=True
+                )
+            else:
+                __log__.info("Updated configuration file with new values!")
 
 
 def main():
@@ -51,50 +93,31 @@ def main():
                         help="Output debug information (default: %(default)s)")
     args = parser.parse_args()
 
-    config_data = args.config.read()
-    config = configparser.ConfigParser()
-    config.read_string(config_data)
+    with _manage_config(args.config) as config:
+        client_id = config['api']['client_id']
+        client_secret = config['api']['client_secret']
+        refresh_token = config['api']['refresh_token']
+        output_dir = os.path.expanduser(config['global'].get('output_dir', OUTPUT_DIR))
+        email = config['user']['email']
+        password = config['user']['password']
+        jwt = config['user'].get('jwt')
 
-    client_id = config['api']['client_id']
-    client_secret = config['api']['client_secret']
-    refresh_token = config['api']['refresh_token']
-    output_dir = os.path.expanduser(config['global'].get('output_dir', OUTPUT_DIR))
-    email = config['user']['email']
-    password = config['user']['password']
-    jwt = config['user'].get('jwt')
+        # Reduce logspam
+        logging.getLogger("stravalib.model").setLevel(logging.INFO)
+        logging.getLogger("stravalib.attributes").setLevel(logging.ERROR)
+        logging.getLogger("stravaweblib.model").setLevel(logging.INFO)
+        logging.basicConfig(format=LOG_FORMAT,
+                            level=logging.DEBUG if args.debug else
+                                  logging.ERROR if args.quiet else logging.INFO)
 
-    # Reduce logspam
-    logging.getLogger("stravalib.model").setLevel(logging.INFO)
-    logging.getLogger("stravalib.attributes").setLevel(logging.ERROR)
-    logging.getLogger("stravaweblib.model").setLevel(logging.INFO)
-    logging.basicConfig(format=LOG_FORMAT,
-                        level=logging.DEBUG if args.debug else
-                              logging.ERROR if args.quiet else logging.INFO)
+        __log__.info("Using the refresh token to get an access token")
+        tokens = Client().refresh_access_token(client_id, client_secret, refresh_token)
+        if tokens['refresh_token'] != refresh_token:
+            __log__.info("Refresh token has changed, will attempt to update the config file")
+            config['api']['refresh_token'] = refresh_token
+            config._updated = True
 
-    __log__.info("Using the refresh token to get an access token")
-    tokens = Client().refresh_access_token(client_id, client_secret, refresh_token)
-    if tokens['refresh_token'] != refresh_token:
-        refresh_token = tokens['refresh_token']
-        config_path = args.config.name
-        __log__.info("Refresh token has changed, updating the config file")
-        try:
-            if config_path == "<stdin>":
-                raise FileNotFoundError("Cannot write to config file passed via stdin")
-            with open(config_path, 'w') as f:
-                new_config = re.sub(
-                    r'^(\s*refresh_token\s*=\s*)\w+(.*)$',
-                    r'\1{}\2'.format(refresh_token),
-                    config_data
-                )
-                f.write(new_config)
-        except OSError:
-            __log__.warning(
-                "Failed to automatically update refresh token in the config file - "
-                "please update it manually", exc_info=True
-            )
-            __log__.warning("New refresh token is '%s'", refresh_token)
-
-    access_token = tokens['access_token']
+        access_token = tokens['access_token']
 
     if args.dry_run:
         __log__.info("Would backup '%s' to '%s'", email, output_dir)

--- a/stravabackup/strava-backup.conf
+++ b/stravabackup/strava-backup.conf
@@ -9,3 +9,4 @@ refresh_token=<YOUR API REFRESH TOKEN>
 [user]
 email=<YOUR EMAIL>
 password=<YOUR PASSWORD>
+#jwt=<optional JWT token (eyJ...)>


### PR DESCRIPTION
- Support using JWT tokens in the config file
- Improve how automatic updates to the config file are done
- Automatically store and update JWT tokens extracted from a logged in session in the config. This will reduce the amount of times that the script has to log in via email+password.