### PR TITLE
date time format of files: fix typo

### DIFF
--- a/stravabackup/__init__.py
+++ b/stravabackup/__init__.py
@@ -21,8 +21,8 @@ from stravalib.exc import AuthError
 __all__ = ["StravaBackup"]
 __log__ = logging.getLogger(__name__)
 
-TIME_FMT = "%Y-%m-%dT%H:%m:%SZ"
-TIME_FMT_FILE = "%Y-%m-%dT%H-%m-%SZ"
+TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+TIME_FMT_FILE = "%Y-%m-%dT%H-%M-%SZ"
 
 META_EXTENSION = "meta.json"
 ACTIVITY_FILENAME = "{start}_{id}.{ext}"


### PR DESCRIPTION
%m is the month, %M is the minute. This caused e.g. a past activity of mine to be named 2026-03-14T14-03-07Z_17720858676.meta.json instead of 2026-03-14T14-14-07Z_17720858676.meta.json.

See
<https://docs.python.org/3.13/library/datetime.html#strftime-and-strptime-format-codes>.